### PR TITLE
Style redo of infected-types.md along with code clean up

### DIFF
--- a/infected-types.md
+++ b/infected-types.md
@@ -42,7 +42,7 @@
 
 ---
 
-<img src="https://i.imgur.com/LrofAba.png" align="left" width="30%">
+<img src="https://i.imgur.com/LrofAba.png" align="left" width="40%">
 
 ### Bat Infected:
 
@@ -63,7 +63,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/W5raT0J.png" align="left" width="30%">
+<img src="https://i.imgur.com/W5raT0J.png" align="left" width="40%">
 
 ### Bee Infected:
 
@@ -85,7 +85,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/rfiS3lr.png" align="left" width="30%">
+<img src="https://i.imgur.com/rfiS3lr.png" align="left" width="40%">
 
 ### Cat Infected:
 
@@ -106,7 +106,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/r5xYT3a.png" align="left" width="30%">
+<img src="https://i.imgur.com/r5xYT3a.png" align="left" width="40%">
 
 ### Deer Infected:
 
@@ -127,7 +127,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/lNFaAVL.png" align="left" width="30%">
+<img src="https://i.imgur.com/lNFaAVL.png" align="left" width="40%">
 
 ### Dragon Infected:
 
@@ -148,7 +148,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/9RM1Oc9.png" align="left" width="30%">
+<img src="https://i.imgur.com/9RM1Oc9.png" align="left" width="40%">
 
 ### Fox Infected:
 
@@ -169,7 +169,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/qc75poP.png" align="left" width="30%">
+<img src="https://i.imgur.com/qc75poP.png" align="left" width="40%">
 
 ### Hedgehog Infected:
 
@@ -190,7 +190,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/RA1XpYJ.png" align="left" width="30%">
+<img src="https://i.imgur.com/RA1XpYJ.png" align="left" width="40%">
 
 ### Moth Infected:
 
@@ -212,7 +212,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/ruYBaME.png" align="left" width="30%">
+<img src="https://i.imgur.com/ruYBaME.png" align="left" width="40%">
 
 ### Protogen Infected:
 
@@ -233,7 +233,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/JdbvACp.png" align="left" width="30%">
+<img src="https://i.imgur.com/JdbvACp.png" align="left" width="40%">
 
 ### Rat Infected:
 
@@ -255,7 +255,7 @@
 
 ---
 
-<img src="https://i.imgur.com/ARAjhpu.png" align="left" width="30%">
+<img src="https://i.imgur.com/ARAjhpu.png" align="left" width="40%">
 
 ### Shark Infected:
 
@@ -276,7 +276,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/s60ieY4.png" align="left" width="30%">
+<img src="https://i.imgur.com/s60ieY4.png" align="left" width="40%">
 
 ### Sheep Infected:
 
@@ -297,7 +297,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/qs5IpoH.png" align="left" width="30%">
+<img src="https://i.imgur.com/qs5IpoH.png" align="left" width="40%">
 
 ### Squirrel Infected:
 
@@ -318,7 +318,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/5gDVh5l.png" align="left" width="30%">
+<img src="https://i.imgur.com/5gDVh5l.png" align="left" width="40%">
 
 ### Void Infected:
 
@@ -339,7 +339,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/NWinaTN.png" align="left" width="30%">
+<img src="https://i.imgur.com/NWinaTN.png" align="left" width="40%">
 
 ### Wolf Infected:
 
@@ -360,7 +360,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/moxs8cJ.png" align="left" width="30%">
+<img src="https://i.imgur.com/moxs8cJ.png" align="left" width="40%">
 
 ### Wyvern Infected:
 

--- a/infected-types.md
+++ b/infected-types.md
@@ -42,23 +42,30 @@
 
 ---
 
-### Bat Infected:
+<img src="https://i.imgur.com/LrofAba.png" align="left" width="20%">
 
-<img src="https://i.imgur.com/LrofAba.png" width="65%" height="70%">
+### Bat Infected:
 
 ---
 <div style="font-size:120%;">
   <p><span style="color:rgb(255,0,0);">Damage:</span> 1</p>
   <p><span style="color:rgb(0,255,0);">Health:</span> 1 </p>
-  <p><span style="color:rgb(255,255,0);">Jump:</span> 1.2 </p> 
+  <p><span style="color:rgb(255,255,0);">Jump:</span> 1.2 </p>
   <p><span style="color:rgb(0,255,255);">Speed:</span> 1.05 </p>
 </div>
 
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
 ---
+<img src="https://i.imgur.com/W5raT0J.png" align="left" width="20%">
 
 ### Bee Infected:
-
-<img src="https://i.imgur.com/W5raT0J.png" width="65%" height="70%">
 
 <font size="4"><strong>This is one of the infected types that can glide!</strong></font>
 
@@ -69,82 +76,123 @@
   <p><span style="color:rgb(0,255,255);">Speed:</span> 1 </p>
 </div>
 
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
 ---
+<img src="https://i.imgur.com/rfiS3lr.png" align="left" width="20%">
 
 ### Cat Infected:
-
-<img src="https://i.imgur.com/rfiS3lr.png" width="65%" height="70%">
 
 ---
 <div style="font-size:120%;">
   <p><span style="color:rgb(255,0,0);">Damage:</span> 1.1</p>
   <p><span style="color:rgb(0,255,0);">Health:</span> 1.1 </p>
-  <p><span style="color:rgb(255,255,0);">Jump:</span> 1 </p> 
+  <p><span style="color:rgb(255,255,0);">Jump:</span> 1 </p>
   <p><span style="color:rgb(0,255,255);">Speed:</span> 1.02 </p>
 </div>
 
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
 ---
+<img src="https://i.imgur.com/r5xYT3a.png" align="left" width="20%">
 
 ### Deer Infected:
-
-<img src="https://i.imgur.com/r5xYT3a.png" width="65%" height="70%">
 
 ---
 <div style="font-size:120%;">
   <p><span style="color:rgb(255,0,0);">Damage:</span> 1</p>
   <p><span style="color:rgb(0,255,0);">Health:</span> 0.95 </p>
-  <p><span style="color:rgb(255,255,0);">Jump:</span> 1 </p> 
+  <p><span style="color:rgb(255,255,0);">Jump:</span> 1 </p>
   <p><span style="color:rgb(0,255,255);">Speed:</span> 1.08 </p>
 </div>
 
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
 ---
+<img src="https://i.imgur.com/lNFaAVL.png" align="left" width="20%">
 
 ### Dragon Infected:
-
-<img src="https://i.imgur.com/lNFaAVL.png" width="65%" height="70%">
 
 ---
 <div style="font-size:120%;">
   <p><span style="color:rgb(255,0,0);">Damage:</span> 1</p>
   <p><span style="color:rgb(0,255,0);">Health:</span> 1.25 </p>
-  <p><span style="color:rgb(255,255,0);">Jump:</span> 1.5 </p> 
+  <p><span style="color:rgb(255,255,0);">Jump:</span> 1.5 </p>
   <p><span style="color:rgb(0,255,255);">Speed:</span> 1 </p>
 </div>
 
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
 ---
+<img src="https://i.imgur.com/9RM1Oc9.png" align="left" width="20%">
 
 ### Fox Infected:
-
-
-<img src="https://i.imgur.com/9RM1Oc9.png" width="65%" height="70%">
 
 ---
 <div style="font-size:120%;">
   <p><span style="color:rgb(255,0,0);">Damage:</span> 1</p>
   <p><span style="color:rgb(0,255,0);">Health:</span> 1.5 </p>
-  <p><span style="color:rgb(255,255,0);">Jump:</span> 1 </p> 
+  <p><span style="color:rgb(255,255,0);">Jump:</span> 1 </p>
   <p><span style="color:rgb(0,255,255);">Speed:</span> 0.95 </p>
 </div>
 
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
 ---
+<img src="https://i.imgur.com/qc75poP.png" align="left" width="20%">
 
 ### Hedgehog Infected:
-
-<img src="https://i.imgur.com/qc75poP.png" width="65%" height="70%">
 
 ---
 <div style="font-size:120%;">
   <p><span style="color:rgb(255,0,0);">Damage:</span> 1.3</p>
   <p><span style="color:rgb(0,255,0);">Health:</span> 1 </p>
-  <p><span style="color:rgb(255,255,0);">Jump:</span> 0.8 </p> 
+  <p><span style="color:rgb(255,255,0);">Jump:</span> 0.8 </p>
   <p><span style="color:rgb(0,255,255);">Speed:</span> 1.2 </p>
 </div>
 
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
 ---
+<img src="https://i.imgur.com/RA1XpYJ.png" align="left" width="20%">
 
 ### Moth Infected:
-
-<img src="https://i.imgur.com/RA1XpYJ.png" width="65%" height="70%">
 
 <font size="4"><strong>This is one of the infected types that can glide!</strong></font>
 
@@ -155,122 +203,174 @@
   <p><span style="color:rgb(0,255,255);">Speed:</span> 1.025</p>
 </div>
 
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
 ---
+<img src="https://i.imgur.com/ruYBaME.png" align="left" width="20%">
 
 ### Protogen Infected:
-
-<img src="https://i.imgur.com/ruYBaME.png" width="65%" height="70%">
 
 ---
 <div style="font-size:120%;">
   <p><span style="color:rgb(255,0,0);">Damage:</span> 1</p>
   <p><span style="color:rgb(0,255,0);">Health:</span> 2.5 </p>
-  <p><span style="color:rgb(255,255,0);">Jump:</span> 0.85 </p> 
+  <p><span style="color:rgb(255,255,0);">Jump:</span> 0.85 </p>
   <p><span style="color:rgb(0,255,255);">Speed:</span> 0.75 </p>
 </div>
 
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
 ---
+<img src="https://i.imgur.com/JdbvACp.png" align="left" width="20%">
 
 ### Rat Infected:
-
-<img src="https://i.imgur.com/JdbvACp.png" width="65%" height="70%">
 
 ---
 <div style="font-size:120%;">
   <p><span style="color:rgb(255,0,0);">Damage:</span> 2</p>
   <p><span style="color:rgb(0,255,0);">Health:</span> 0.55 </p>
-  <p><span style="color:rgb(255,255,0);">Jump:</span> 1 </p> 
+  <p><span style="color:rgb(255,255,0);">Jump:</span> 1 </p>
   <p><span style="color:rgb(0,255,255);">Speed:</span> 1.2 </p>
 </div>
 
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
 ---
 
+<img src="https://i.imgur.com/ARAjhpu.png" align="left" width="20%">
 
 ### Shark Infected:
-
-<img src="https://i.imgur.com/ARAjhpu.png" width="65%" height="70%">
 
 ---
 <div style="font-size:120%;">
   <p><span style="color:rgb(255,0,0);">Damage:</span> 1.2</p>
   <p><span style="color:rgb(0,255,0);">Health:</span> 0.95 </p>
-  <p><span style="color:rgb(255,255,0);">Jump:</span> 0.8 </p> 
+  <p><span style="color:rgb(255,255,0);">Jump:</span> 0.8 </p>
   <p><span style="color:rgb(0,255,255);">Speed:</span> 1.25 </p>
 </div>
 
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
 ---
+<img src="https://i.imgur.com/s60ieY4.png" align="left" width="20%">
 
 ### Sheep Infected:
-
-<img src="https://i.imgur.com/s60ieY4.png" width="65%" height="70%">
 
 ---
 <div style="font-size:120%;">
   <p><span style="color:rgb(255,0,0);">Damage:</span> 1</p>
   <p><span style="color:rgb(0,255,0);">Health:</span> 1 </p>
-  <p><span style="color:rgb(255,255,0);">Jump:</span> 1 </p> 
+  <p><span style="color:rgb(255,255,0);">Jump:</span> 1 </p>
   <p><span style="color:rgb(0,255,255);">Speed:</span> 1 </p>
 </div>
 
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
 ---
+<img src="https://i.imgur.com/qs5IpoH.png" align="left" width="20%">
 
 ### Squirrel Infected:
-
-<img src="https://i.imgur.com/qs5IpoH.png" width="65%" height="70%">
 
 ---
 <div style="font-size:120%;">
   <p><span style="color:rgb(255,0,0);">Damage:</span> 0.95</p>
   <p><span style="color:rgb(0,255,0);">Health:</span> 1.1 </p>
-  <p><span style="color:rgb(255,255,0);">Jump:</span> 1 </p> 
+  <p><span style="color:rgb(255,255,0);">Jump:</span> 1 </p>
   <p><span style="color:rgb(0,255,255);">Speed:</span> 1.05 </p>
 </div>
 
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
 ---
+<img src="https://i.imgur.com/5gDVh5l.png" align="left" width="20%">
 
 ### Void Infected:
-
-<img src="https://i.imgur.com/5gDVh5l.png" width="95%" height="70%">
 
 ---
 <div style="font-size:120%;">
   <p><span style="color:rgb(255,0,0);">Damage:</span> 1.3</p>
   <p><span style="color:rgb(0,255,0);">Health:</span> 1 </p>
-  <p><span style="color:rgb(255,255,0);">Jump:</span> 1 </p> 
+  <p><span style="color:rgb(255,255,0);">Jump:</span> 1 </p>
   <p><span style="color:rgb(0,255,255);">Speed:</span> 1.08 </p>
 </div>
 
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
 ---
+<img src="https://i.imgur.com/NWinaTN.png" align="left" width="20%">
 
 ### Wolf Infected:
-
-<img src="https://i.imgur.com/NWinaTN.png" width="65%" height="70%">
 
 ---
 <div style="font-size:120%;">
   <p><span style="color:rgb(255,0,0);">Damage:</span> 1.5</p>
   <p><span style="color:rgb(0,255,0);">Health:</span> 2 </p>
-  <p><span style="color:rgb(255,255,0);">Jump:</span> 0.8 </p> 
+  <p><span style="color:rgb(255,255,0);">Jump:</span> 0.8 </p>
   <p><span style="color:rgb(0,255,255);">Speed:</span> 0.95 </p>
 </div>
 
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
+&nbsp;
+
 ---
+<img src="https://i.imgur.com/moxs8cJ.png" align="left" width="20%">
 
 ### Wyvern Infected:
-
-<img src="https://i.imgur.com/moxs8cJ.png" width="95%" height="70%">
 
 ---
 <div style="font-size:120%;">
   <p><span style="color:rgb(255,0,0);">Damage:</span> 1.2</p>
   <p><span style="color:rgb(0,255,0);">Health:</span> 1.1 </p>
-  <p><span style="color:rgb(255,255,0);">Jump:</span> 1 </p> 
+  <p><span style="color:rgb(255,255,0);">Jump:</span> 1 </p>
   <p><span style="color:rgb(0,255,255);">Speed:</span> 1.01 </p>
 </div>
-
-
-
-
 
 &nbsp;
 

--- a/infected-types.md
+++ b/infected-types.md
@@ -42,7 +42,7 @@
 
 ---
 
-<img src="https://i.imgur.com/LrofAba.png" align="left" width="20%">
+<img src="https://i.imgur.com/LrofAba.png" align="left" width="25%">
 
 ### Bat Infected:
 
@@ -63,7 +63,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/W5raT0J.png" align="left" width="20%">
+<img src="https://i.imgur.com/W5raT0J.png" align="left" width="25%">
 
 ### Bee Infected:
 
@@ -85,7 +85,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/rfiS3lr.png" align="left" width="20%">
+<img src="https://i.imgur.com/rfiS3lr.png" align="left" width="25%">
 
 ### Cat Infected:
 
@@ -106,7 +106,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/r5xYT3a.png" align="left" width="20%">
+<img src="https://i.imgur.com/r5xYT3a.png" align="left" width="25%">
 
 ### Deer Infected:
 
@@ -127,7 +127,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/lNFaAVL.png" align="left" width="20%">
+<img src="https://i.imgur.com/lNFaAVL.png" align="left" width="25%">
 
 ### Dragon Infected:
 
@@ -148,7 +148,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/9RM1Oc9.png" align="left" width="20%">
+<img src="https://i.imgur.com/9RM1Oc9.png" align="left" width="25%">
 
 ### Fox Infected:
 
@@ -169,7 +169,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/qc75poP.png" align="left" width="20%">
+<img src="https://i.imgur.com/qc75poP.png" align="left" width="25%">
 
 ### Hedgehog Infected:
 
@@ -190,7 +190,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/RA1XpYJ.png" align="left" width="20%">
+<img src="https://i.imgur.com/RA1XpYJ.png" align="left" width="25%">
 
 ### Moth Infected:
 
@@ -212,7 +212,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/ruYBaME.png" align="left" width="20%">
+<img src="https://i.imgur.com/ruYBaME.png" align="left" width="25%">
 
 ### Protogen Infected:
 
@@ -233,7 +233,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/JdbvACp.png" align="left" width="20%">
+<img src="https://i.imgur.com/JdbvACp.png" align="left" width="25%">
 
 ### Rat Infected:
 
@@ -255,7 +255,7 @@
 
 ---
 
-<img src="https://i.imgur.com/ARAjhpu.png" align="left" width="20%">
+<img src="https://i.imgur.com/ARAjhpu.png" align="left" width="25%">
 
 ### Shark Infected:
 
@@ -276,7 +276,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/s60ieY4.png" align="left" width="20%">
+<img src="https://i.imgur.com/s60ieY4.png" align="left" width="25%">
 
 ### Sheep Infected:
 
@@ -297,7 +297,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/qs5IpoH.png" align="left" width="20%">
+<img src="https://i.imgur.com/qs5IpoH.png" align="left" width="25%">
 
 ### Squirrel Infected:
 
@@ -318,7 +318,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/5gDVh5l.png" align="left" width="20%">
+<img src="https://i.imgur.com/5gDVh5l.png" align="left" width="25%">
 
 ### Void Infected:
 
@@ -339,7 +339,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/NWinaTN.png" align="left" width="20%">
+<img src="https://i.imgur.com/NWinaTN.png" align="left" width="25%">
 
 ### Wolf Infected:
 
@@ -360,7 +360,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/moxs8cJ.png" align="left" width="20%">
+<img src="https://i.imgur.com/moxs8cJ.png" align="left" width="25%">
 
 ### Wyvern Infected:
 

--- a/infected-types.md
+++ b/infected-types.md
@@ -42,7 +42,7 @@
 
 ---
 
-<img src="https://i.imgur.com/LrofAba.png" align="left" width="25%">
+<img src="https://i.imgur.com/LrofAba.png" align="left" width="30%">
 
 ### Bat Infected:
 
@@ -63,7 +63,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/W5raT0J.png" align="left" width="25%">
+<img src="https://i.imgur.com/W5raT0J.png" align="left" width="30%">
 
 ### Bee Infected:
 
@@ -85,7 +85,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/rfiS3lr.png" align="left" width="25%">
+<img src="https://i.imgur.com/rfiS3lr.png" align="left" width="30%">
 
 ### Cat Infected:
 
@@ -106,7 +106,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/r5xYT3a.png" align="left" width="25%">
+<img src="https://i.imgur.com/r5xYT3a.png" align="left" width="30%">
 
 ### Deer Infected:
 
@@ -127,7 +127,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/lNFaAVL.png" align="left" width="25%">
+<img src="https://i.imgur.com/lNFaAVL.png" align="left" width="30%">
 
 ### Dragon Infected:
 
@@ -148,7 +148,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/9RM1Oc9.png" align="left" width="25%">
+<img src="https://i.imgur.com/9RM1Oc9.png" align="left" width="30%">
 
 ### Fox Infected:
 
@@ -169,7 +169,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/qc75poP.png" align="left" width="25%">
+<img src="https://i.imgur.com/qc75poP.png" align="left" width="30%">
 
 ### Hedgehog Infected:
 
@@ -190,7 +190,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/RA1XpYJ.png" align="left" width="25%">
+<img src="https://i.imgur.com/RA1XpYJ.png" align="left" width="30%">
 
 ### Moth Infected:
 
@@ -212,7 +212,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/ruYBaME.png" align="left" width="25%">
+<img src="https://i.imgur.com/ruYBaME.png" align="left" width="30%">
 
 ### Protogen Infected:
 
@@ -233,7 +233,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/JdbvACp.png" align="left" width="25%">
+<img src="https://i.imgur.com/JdbvACp.png" align="left" width="30%">
 
 ### Rat Infected:
 
@@ -255,7 +255,7 @@
 
 ---
 
-<img src="https://i.imgur.com/ARAjhpu.png" align="left" width="25%">
+<img src="https://i.imgur.com/ARAjhpu.png" align="left" width="30%">
 
 ### Shark Infected:
 
@@ -276,7 +276,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/s60ieY4.png" align="left" width="25%">
+<img src="https://i.imgur.com/s60ieY4.png" align="left" width="30%">
 
 ### Sheep Infected:
 
@@ -297,7 +297,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/qs5IpoH.png" align="left" width="25%">
+<img src="https://i.imgur.com/qs5IpoH.png" align="left" width="30%">
 
 ### Squirrel Infected:
 
@@ -318,7 +318,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/5gDVh5l.png" align="left" width="25%">
+<img src="https://i.imgur.com/5gDVh5l.png" align="left" width="30%">
 
 ### Void Infected:
 
@@ -339,7 +339,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/NWinaTN.png" align="left" width="25%">
+<img src="https://i.imgur.com/NWinaTN.png" align="left" width="30%">
 
 ### Wolf Infected:
 
@@ -360,7 +360,7 @@
 &nbsp;
 
 ---
-<img src="https://i.imgur.com/moxs8cJ.png" align="left" width="25%">
+<img src="https://i.imgur.com/moxs8cJ.png" align="left" width="30%">
 
 ### Wyvern Infected:
 


### PR DESCRIPTION
# Summary

## Style redo

Moved the position of the images to the left to allow for more compact information on top of a cleaner look to the overall site on top of some other minor changes to aid these goals.

<div align="center">
<img src="https://i.imgur.com/kRm8Tzs.png" width=50%>
</div>

## Clean up

Fixed various mistakes according to the markdown guidelines on top of removing unnecessary spaces and blank lines